### PR TITLE
Fixes Typos in Master-Theorem Geometrische Reihe

### DIFF
--- a/lectures-tex/lecture06.tex
+++ b/lectures-tex/lecture06.tex
@@ -302,7 +302,7 @@
     \end{figure}
 
     \begin{equation*}
-        \sum^{\log_b(n)}_{l=0} n^c \cdot \underbrace{\left( \frac{a}{b^c}\right)^l}_{q} = n^2 \cdot \sum^{\log_b(n)}_{l=0} q^k \quad \text{(Geom. Reihe)}
+        \sum^{\log_b(n)}_{l=0} n^c \cdot \underbrace{\left( \frac{a}{b^c}\right)^l}_{q} = n^c \cdot \sum^{\log_b(n)}_{l=0} q^l \quad \text{(Geom. Reihe)}
     \end{equation*}
     \begin{equation*}
         \text{Also }


### PR DESCRIPTION
In der Formel der Geometrischen Reihe aus Vorlesung 6 waren 2 Tippfehler. Dieser Pull Request fixed die.