### PR TITLE
Vorlesungstabelle mit Themen der Vorlesungen

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Mitschriften zur Vorlesung *AuB17/18* der Uni Stuttgart. Kein Anspruch auf Korrektheit.
 
-<table>
-<tr><td>
 
 |Vorlesung      | Datum der VL |PDF                                    |Thema
 |---------------|--------------|---------------------------------------|----------------------------------
@@ -17,7 +15,7 @@ Mitschriften zur Vorlesung *AuB17/18* der Uni Stuttgart. Kein Anspruch auf Korre
 |08             | 21.11.2017   |[klick](lectures-pdf/lecture08.pdf)    |Perfektes Hashing
 |09             | 24.11.2017   |[klick](lectures-pdf/lecture09.pdf)    |Perfektes Hashing, Cuckoo-Hashing
 |10             | 28.11.2017   |[klick](lectures-pdf/lecture10.pdf)    |Contraction Hierarchies
-</td><td>
+
 
 |Vorlesung      | Datum der VL |PDF                                    |Thema
 |---------------|--------------|---------------------------------------|----------------------------------
@@ -32,8 +30,6 @@ Mitschriften zur Vorlesung *AuB17/18* der Uni Stuttgart. Kein Anspruch auf Korre
 | 19            |              |                                       |
 | 20            |              |                                       |
 
-</td>
-<!-- <td>
 
 |Vorlesung      | Datum der VL |PDF                                    |Thema
 |---------------|--------------|---------------------------------------|----------------------------------
@@ -48,7 +44,6 @@ Mitschriften zur Vorlesung *AuB17/18* der Uni Stuttgart. Kein Anspruch auf Korre
 | 29            |              |                                       |
 | 30            |              |                                       |
 
-</td> --></tr> </table>
 
 ## Mitmachen
 Hilfe ist gern gesehen. Ob Grafiken, Mitschriften der Vorlesung in Text- oder Texform oder einfach nur Korrektur.

--- a/README.md
+++ b/README.md
@@ -15,10 +15,6 @@ Mitschriften zur Vorlesung *AuB17/18* der Uni Stuttgart. Kein Anspruch auf Korre
 |08             | 21.11.2017   |[klick](lectures-pdf/lecture08.pdf)    |Perfektes Hashing
 |09             | 24.11.2017   |[klick](lectures-pdf/lecture09.pdf)    |Perfektes Hashing, Cuckoo-Hashing
 |10             | 28.11.2017   |[klick](lectures-pdf/lecture10.pdf)    |Contraction Hierarchies
-
-
-|Vorlesung      | Datum der VL |PDF                                    |Thema
-|---------------|--------------|---------------------------------------|----------------------------------
 | 11            | 05.12.2017   |[klick](lectures-pdf/lecture11.pdf)    |Berechenbarkeit/TMs
 | 12            | 08.12.2017   |[klick](lectures-pdf/lecture12.pdf)    |Mehrband TMs
 | 13            | 12.12.2017   |[klick](lectures-pdf/lecture13.pdf)    |Universelle TM
@@ -29,10 +25,6 @@ Mitschriften zur Vorlesung *AuB17/18* der Uni Stuttgart. Kein Anspruch auf Korre
 | 18            |              |                                       |
 | 19            |              |                                       |
 | 20            |              |                                       |
-
-
-|Vorlesung      | Datum der VL |PDF                                    |Thema
-|---------------|--------------|---------------------------------------|----------------------------------
 | 21            |              |                                       |
 | 22            |              |                                       |
 | 23            |              |                                       |

--- a/README.md
+++ b/README.md
@@ -5,26 +5,26 @@ Mitschriften zur Vorlesung *AuB17/18* der Uni Stuttgart. Kein Anspruch auf Korre
 <table>
 <tr><td>
 
-|Vorlesung      | Datum der VL |PDF                                    |
-|---------------|--------------|---------------------------------------|
-|01             | 17.10.2017   |[klick](lectures-pdf/lecture01.pdf)    |
-|02             | 20.10.2017   |[klick](lectures-pdf/lecture02.pdf)    |
-|03             | 24.10.2017   |[klick](lectures-pdf/lecture03.pdf)    |
-|04             | 27.10.2017   |[klick](lectures-pdf/lecture04.pdf)    |
-|05             | 07.11.2017   |[klick](lectures-pdf/lecture05.pdf)    |
-|06             | 10.11.2017   |[klick](lectures-pdf/lecture06.pdf)    |
-|07             | 14.11.2017   |[klick](lectures-pdf/lecture07.pdf)    |
-|08             | 21.11.2017   |[klick](lectures-pdf/lecture08.pdf)    |
-|09             | 24.11.2017   |[klick](lectures-pdf/lecture09.pdf)    |
-|10             | 28.11.2017   |[klick](lectures-pdf/lecture10.pdf)    |
+|Vorlesung      | Datum der VL |PDF                                    |Thema
+|---------------|--------------|---------------------------------------|----------------------------------
+|01             | 17.10.2017   |[klick](lectures-pdf/lecture01.pdf)    |Closest Pair
+|02             | 20.10.2017   |[klick](lectures-pdf/lecture02.pdf)    |Min Cut
+|03             | 24.10.2017   |[klick](lectures-pdf/lecture03.pdf)    |Monte-Carlo, Las Vegas
+|04             | 27.10.2017   |[klick](lectures-pdf/lecture04.pdf)    |Quicksort, Zero-Knowledge-Proof
+|05             | 07.11.2017   |[klick](lectures-pdf/lecture05.pdf)    |Quickselect
+|06             | 10.11.2017   |[klick](lectures-pdf/lecture06.pdf)    |Skiplisten
+|07             | 14.11.2017   |[klick](lectures-pdf/lecture07.pdf)    |Hashing
+|08             | 21.11.2017   |[klick](lectures-pdf/lecture08.pdf)    |Perfektes Hashing
+|09             | 24.11.2017   |[klick](lectures-pdf/lecture09.pdf)    |Perfektes Hashing, Cuckoo-Hashing
+|10             | 28.11.2017   |[klick](lectures-pdf/lecture10.pdf)    |Contraction Hierarchies
 </td><td>
 
-|Vorlesung      | Datum der VL |PDF                                    |
-|---------------|--------------|---------------------------------------|
-| 11            | 05.12.2017   |[klick](lectures-pdf/lecture11.pdf)    |
-| 12            | 08.12.2017   |[klick](lectures-pdf/lecture12.pdf)    |
-| 13            | 12.12.2017   |[klick](lectures-pdf/lecture13.pdf)    |
-| 14            | 19.12.2017   |[klick](lectures-pdf/lecture14.pdf)   |
+|Vorlesung      | Datum der VL |PDF                                    |Thema
+|---------------|--------------|---------------------------------------|----------------------------------
+| 11            | 05.12.2017   |[klick](lectures-pdf/lecture11.pdf)    |Berechenbarkeit/TMs
+| 12            | 08.12.2017   |[klick](lectures-pdf/lecture12.pdf)    |Mehrband TMs
+| 13            | 12.12.2017   |[klick](lectures-pdf/lecture13.pdf)    |Universelle TM
+| 14            | 19.12.2017   |[klick](lectures-pdf/lecture14.pdf)    |Halteproblem
 | 15            | 22.12.2017   | Scheinklausur                         |
 | 16            |              |                                       |
 | 17            |              |                                       |
@@ -35,8 +35,8 @@ Mitschriften zur Vorlesung *AuB17/18* der Uni Stuttgart. Kein Anspruch auf Korre
 </td>
 <!-- <td>
 
-|Vorlesung      | Datum der VL |PDF                                    |
-|---------------|--------------|---------------------------------------|
+|Vorlesung      | Datum der VL |PDF                                    |Thema
+|---------------|--------------|---------------------------------------|----------------------------------
 | 21            |              |                                       |
 | 22            |              |                                       |
 | 23            |              |                                       |


### PR DESCRIPTION
Dieser PR fügt in die Tabelle mit den Vorlesungen eine Thema Spalte ein, sodass man bei Suche nach einem bestimmten Thema sofort weiß, welche Vorlesungspdf geöffnet werden muss.

Dadurch sind die Tabellen breiter geworden, weshalb eine Ansicht von zwei Tabellen nebeneinander nicht mehr gut funktioniert hat. Alle Vorlesungen sind daher in einer einzigen langen Tabelle angeordnet.