### PR TITLE
Halteproblem unentscheidbarkeit Beweis mit Diagonalsprache

### DIFF
--- a/lectures-tex/lecture14.tex
+++ b/lectures-tex/lecture14.tex
@@ -111,7 +111,7 @@
         \item $w \in \overline{\mathcal{D}} \Rightarrow \mathcal{M}_\mathcal{H}$ akzeptiert $<M_{i}>w$ im dritten Schritt
         (da $M_i$ das $w=w_i$ im vierten Schritt akzeptiert und damit auch stoppt)
         $\Rightarrow \mathcal{M}_{\overline{\mathcal{D}}}$ akzeptiert $w$.
-        \item $w \in \overline{\mathcal{D}} \Rightarrow$
+        \item $w \notin \overline{\mathcal{D}} \Rightarrow$
         \begin{itemize}
             \item $\mathcal{M}_\mathcal{H}$ verwirft $<M_{i}>w$ im dritten Schritt, da $M_i$ auf $w$ nicht hält.
             \newline $\Rightarrow \mathcal{M}_{\overline{\mathcal{D}}}$ verwirft $w$.


### PR DESCRIPTION
Halteproblem unentscheidbarkeit Beweis mit Diagonalsprache. Zweiter Fall ist, dass w nicht in D-Quer ist.