### PR TITLE
Update skiplist pseudocode

### DIFF
--- a/lectures-tex/lecture06.tex
+++ b/lectures-tex/lecture06.tex
@@ -77,7 +77,7 @@
             \STATE $h\gets v.\text{height}$
             \STATE
             \WHILE{ $h > 0$}
-                \WHILE {$x \leq v.\text{forward}[h] \rightarrow \text{key}$}
+                \WHILE {$x \geq v.\text{forward}[h] \rightarrow \text{key}$}
                     \STATE $v\gets v.\text{forward}[h]$
                 \ENDWHILE
                 \STATE $h\gets h-1$


### PR DESCRIPTION
Wenn man weitergeht, wenn das gesuchte x kleiner gleich dem nächsten Turm ist. Dann überspringt man den gesuchten Turm mit Wert X.

Richtig ist:
Man geht weiter zum nächsten Turm, wenn der Nächste Turm kleiner (also links) oder der gesuchte Turm selbst (also gleich) ist -> also x größer gleich dem nächsten Turm.